### PR TITLE
Fix init README formatting to render properly on GitHub

### DIFF
--- a/contrib/init/README.md
+++ b/contrib/init/README.md
@@ -1,12 +1,12 @@
 Sample configuration files for:
-
+```
 SystemD: bitcoind.service
 Upstart: bitcoind.conf
 OpenRC:  bitcoind.openrc
          bitcoind.openrcconf
 CentOS:  bitcoind.init
 OS X:    org.bitcoin.bitcoind.plist
-
+```
 have been made available to assist packagers in creating node packages here.
 
 See doc/init.md for more information.


### PR DESCRIPTION
It's difficult to read on GitHub because it's not using the proper markdown and most of the spaces are being ignored.
