### PR TITLE
add support for guaging double values

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1534,7 +1534,7 @@ UniValue getchaintxstats(const JSONRPCRequest& request)
     ret.push_back(Pair("txcount", (int64_t)pindex->nChainTx));
     ret.push_back(Pair("txrate", ((double)nTxDiff) / nTimeDiff));
     statsClient.gauge("transactions.totalCount", (int64_t)pindex->nChainTx);
-    statsClient.gauge("transactions.txRate", ((double)nTxDiff) / nTimeDiff);
+    statsClient.gaugeDouble("transactions.txRate", ((double)nTxDiff) / nTimeDiff);
 
     return ret;
 }

--- a/src/statsd_client.cpp
+++ b/src/statsd_client.cpp
@@ -178,6 +178,11 @@ int StatsdClient::gauge(const string& key, size_t value, float sample_rate)
     return send(key, value, "g", sample_rate);
 }
 
+int StatsdClient::gaugeDouble(const string& key, double value, float sample_rate)
+{
+    return sendDouble(key, value, "g", sample_rate);
+}
+
 int StatsdClient::timing(const string& key, size_t ms, float sample_rate)
 {
     return send(key, ms, "ms", sample_rate);
@@ -204,6 +209,33 @@ int StatsdClient::send(string key, size_t value, const string &type, float sampl
     else
     {
         snprintf(buf, sizeof(buf), "%s%s:%zd|%s|@%.2f",
+                d->ns.c_str(), key.c_str(), value, type.c_str(), sample_rate);
+    }
+
+    return send(buf);
+}
+
+int StatsdClient::sendDouble(string key, double value, const string &type, float sample_rate)
+{
+    if (!should_send(sample_rate)) {
+        return 0;
+    }
+
+    // partition stats by node name if set
+    if (!d->nodename.empty())
+        key = key + "." + d->nodename;
+
+    cleanup(key);
+
+    char buf[256];
+    if ( fequal( sample_rate, 1.0 ) )
+    {
+        snprintf(buf, sizeof(buf), "%s%s:%f|%s",
+                d->ns.c_str(), key.c_str(), value, type.c_str());
+    }
+    else
+    {
+        snprintf(buf, sizeof(buf), "%s%s:%f|%s|@%.2f",
                 d->ns.c_str(), key.c_str(), value, type.c_str(), sample_rate);
     }
 

--- a/src/statsd_client.h
+++ b/src/statsd_client.h
@@ -26,6 +26,7 @@ class StatsdClient {
         int dec(const std::string& key, float sample_rate = 1.0);
         int count(const std::string& key, size_t value, float sample_rate = 1.0);
         int gauge(const std::string& key, size_t value, float sample_rate = 1.0);
+        int gaugeDouble(const std::string& key, double value, float sample_rate = 1.0);
         int timing(const std::string& key, size_t ms, float sample_rate = 1.0);
 
     public:
@@ -39,6 +40,8 @@ class StatsdClient {
          * type = "c", "g" or "ms"
          */
         int send(std::string key, size_t value,
+                const std::string& type, float sample_rate);
+        int sendDouble(std::string key, double value,
                 const std::string& type, float sample_rate);
 
     protected:


### PR DESCRIPTION
Default gauge function truncates any precision; this is needed for the chainstats txrate metric.